### PR TITLE
httpClientIssue

### DIFF
--- a/example/integration_test/tests.gradle
+++ b/example/integration_test/tests.gradle
@@ -9,7 +9,7 @@
 
 // Configure these based on your system's emulator/simulator names.
 def android_device = "Android SDK built for x86"
-def iOS_device = "iPhone 13"
+def iOS_device = "iPhone 14"
 
 def test_driver_path = "integration_test/test_driver/integration_test.dart"
 def integration_tests_path = "integration_test/features/"

--- a/lib/src/tracked_clients/tracked_dio_client.dart
+++ b/lib/src/tracked_clients/tracked_dio_client.dart
@@ -54,7 +54,9 @@ class TrackedDioClient extends DioForNative {
       }
     }
 
-    tracker = await RequestTracker.create(path);
+    final requestTracker = await RequestTracker.create(path);
+    tracker = requestTracker;
+
     return _dioClient
         .request<T>(path,
             data: data,
@@ -64,23 +66,23 @@ class TrackedDioClient extends DioForNative {
             onSendProgress: onSendProgress,
             onReceiveProgress: onReceiveProgress)
         .then((response) async {
-      await tracker!.setRequestHeaders(response.requestOptions.headers
+      await requestTracker.setRequestHeaders(response.requestOptions.headers
           .map((k, v) => MapEntry(k, <String>[v])));
-      await tracker!.setResponseStatusCode(response.statusCode ?? 404);
-      await tracker!.setResponseHeaders(response.headers.map);
+      await requestTracker.setResponseStatusCode(response.statusCode ?? 404);
+      await requestTracker.setResponseHeaders(response.headers.map);
       return response;
     }, onError: (e, StackTrace stacktrace) async {
       if (e is DioError) {
-        await tracker!.setError(e.toString(), e.stackTrace.toString());
+        await requestTracker.setError(e.toString(), e.stackTrace.toString());
       } else {
         // All errors seem to be wrapped inside DioError, so we can't force
         // coverage for another type of error, but this case will still be
         // handled, just in case.
-        await tracker!.setError(e.toString(), stacktrace.toString());
+        await requestTracker.setError(e.toString(), stacktrace.toString());
       }
       throw e;
     }).whenComplete(() async {
-      await tracker!.reportDone();
+      await requestTracker.reportDone();
     });
   }
 }

--- a/lib/src/tracked_clients/tracked_http_client.dart
+++ b/lib/src/tracked_clients/tracked_http_client.dart
@@ -40,7 +40,8 @@ class TrackedHttpClient extends BaseClient {
     }
 
     final urlString = request.url.toString();
-    tracker = await RequestTracker.create(urlString);
+    final requestTracker = await RequestTracker.create(urlString);
+    tracker = requestTracker;
 
     return _httpClient.send(request).then((response) async {
       final headers = response.request?.headers ?? request.headers;
@@ -48,16 +49,16 @@ class TrackedHttpClient extends BaseClient {
       final responseHeaders =
           response.headers.map((k, v) => MapEntry(k, <String>[v]));
 
-      await tracker!.setRequestHeaders(requestHeaders);
-      await tracker!.setResponseStatusCode(response.statusCode);
-      await tracker!.setResponseHeaders(responseHeaders);
+      await requestTracker.setRequestHeaders(requestHeaders);
+      await requestTracker.setResponseStatusCode(response.statusCode);
+      await requestTracker.setResponseHeaders(responseHeaders);
 
       return response;
     }, onError: (e, StackTrace stacktrace) async {
-      await tracker!.setError(e.toString(), stacktrace.toString());
+      await requestTracker.setError(e.toString(), stacktrace.toString());
       throw e;
     }).whenComplete(() async {
-      await tracker!.reportDone();
+      await requestTracker.reportDone();
     });
   }
 }


### PR DESCRIPTION
When one TrackedHttpClient is used for more than one request, if the second request started before the first is done, the tracker value is changed, and when the first request tried to be closed, there is an exception:
#0      RequestTracker.reportDone (package:appdynamics_agent/src/request_tracker.dart:143:7)
because the value on the tracker is for the second request, not for the first