### PR TITLE
Android uses same logic for mapping logging levels as iOS

### DIFF
--- a/android/src/main/kotlin/com/appdynamics/appdynamics_agent/features/AgentStart.kt
+++ b/android/src/main/kotlin/com/appdynamics/appdynamics_agent/features/AgentStart.kt
@@ -35,7 +35,12 @@ fun AppDynamicsAgentPlugin.start(@NonNull result: MethodChannel.Result, argument
                 .withAppKey(appKey)
 
         if (loggingLevel != null) {
-            builder.withLoggingLevel(loggingLevel)
+            val levels = listOf(
+                Instrumentation.LOGGING_LEVEL_NONE,
+                Instrumentation.LOGGING_LEVEL_INFO,
+                Instrumentation.LOGGING_LEVEL_VERBOSE,
+            )
+            builder.withLoggingLevel(levels[loggingLevel])
         }
 
         if (collectorURL != null) {


### PR DESCRIPTION
Using `loggingLevel: LoggingLevel.none` (or leaving it as default, which is the same) failed to initialise on Android.
Logging levels for Android is set to
```Java
Instrumentation.LOGGING_LEVEL_NONE = 4;
Instrumentation.LOGGING_LEVEL_INFO = 1;
Instrumentation.LOGGING_LEVEL_VERBOSE = 2;
```
and Flutter sends `"loggingLevel": config.loggingLevel.index`, which results in 0, 1 and 2 respectively. Hence trying to set logging level for Android to 0 will just fail when running `Instrumentation.start(config)` from Flutter.

This fix uses the same logic as the iOS start function uses and just use the static fields in the same order as Flutter.