### PR TITLE
chore: Bump Dio to 5.0.1

### DIFF
--- a/lib/src/tracked_clients/tracked_dio_client.dart
+++ b/lib/src/tracked_clients/tracked_dio_client.dart
@@ -5,7 +5,7 @@
  */
 
 import 'package:dio/dio.dart';
-import 'package:dio/native_imp.dart';
+import 'package:dio/io.dart';
 
 import '../../appdynamics_agent.dart';
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -11,7 +11,7 @@ dependencies:
   flutter:
     sdk: flutter
   http: ^0.13.3
-  dio: ^4.0.6
+  dio: ^5.0.1
 
 dev_dependencies:
   flutter_test:

--- a/test/tracked_dio_client_test.dart
+++ b/test/tracked_dio_client_test.dart
@@ -112,7 +112,7 @@ void main() {
 
     const urlString = "https://www.foo.com";
     final error = DioError(
-        type: DioErrorType.other,
+        type: DioErrorType.unknown,
         error: Error(),
         requestOptions: RequestOptions(path: urlString));
 


### PR DESCRIPTION
There was no migration at all needed (for this repository) when moving to Dio 5.